### PR TITLE
Add Compute Shader File Extensions

### DIFF
--- a/packages/prettier-plugin-glsl/README.md
+++ b/packages/prettier-plugin-glsl/README.md
@@ -53,7 +53,7 @@ recognized as GLSL files by default.
 
 `.fp` `.frag` `.frg` `.fs` `.fsh` `.fshader` `.geo` `.geom` `.glsl` `.glslf`
 `.glslv` `.gs` `.gshader` `.rchit` `.rmiss` `.shader` `.tesc` `.tese` `.vert`
-`.vrx` `.vsh` `.vshader`
+`.vrx` `.vsh` `.vshader` `.csh` `.cshader` `.comp`
 
 Note that `.frag` files are recognized as JavaScript files by default. Add the
 following to your Prettier configuration to format them as GLSL.

--- a/packages/prettier-plugin-glsl/src/prettier-plugin.ts
+++ b/packages/prettier-plugin-glsl/src/prettier-plugin.ts
@@ -108,6 +108,9 @@ export const languages: SupportInfo["languages"] = [
       ".vrx",
       ".vsh",
       ".vshader",
+      ".csh",
+      ".cshader",
+      ".comp",
     ],
   },
 ]


### PR DESCRIPTION
The formatter does not seem to have any extensions registered for compute shaders, so I have added a few that I think would commonly be used (I myself use .csh)