### PR TITLE
fix: preserve commas in comma expressions

### DIFF
--- a/packages/prettier-plugin-glsl/fixtures/comma-expression.glsl
+++ b/packages/prettier-plugin-glsl/fixtures/comma-expression.glsl
@@ -1,0 +1,21 @@
+void main() {
+  // comma expression in for loop body
+  float s = 2.;
+  float e = 0.;
+  vec3 p = vec3(0.);
+  for (int j = 0; ++j < 7; )
+    p.xz = abs(p.xz) - 2.3,
+    p.z = 1.5 - abs(p.z - 1.3),
+    p.x = 3. - abs(p.x - 5.),
+    p.y = .9 - abs(p.y - .4),
+    e = 12. * clamp(.3 / min(dot(p, p), 1.), .0, 1.),
+    p = e * p - vec3(7, 1, 1),
+    s *= e;
+
+  // simple comma expression
+  int a, b;
+  a = 1, b = 2;
+
+  // chained comma expression
+  a = 1, b = 2, a = 3, b = 4;
+}

--- a/packages/prettier-plugin-glsl/fixtures/comma-expression.pretty.glsl
+++ b/packages/prettier-plugin-glsl/fixtures/comma-expression.pretty.glsl
@@ -1,0 +1,27 @@
+void main() {
+  // comma expression in for loop body
+  float s = 2.0;
+  float e = 0.0;
+  vec3 p = vec3(0.0);
+  for (int j = 0; ++j < 7; )
+    p.xz = abs(p.xz) - 2.3,
+      p.z = 1.5 - abs(p.z - 1.3),
+      p.x = 3.0 - abs(p.x - 5.0),
+      p.y = 0.9 - abs(p.y - 0.4),
+      e =
+        12.0 *
+        clamp(
+          0.3 / min(dot(p, p), 1.0),
+          0.0,
+          1.0
+        ),
+      p = e * p - vec3(7, 1, 1),
+      s *= e;
+
+  // simple comma expression
+  int a, b;
+  a = 1, b = 2;
+
+  // chained comma expression
+  a = 1, b = 2, a = 3, b = 4;
+}

--- a/packages/prettier-plugin-glsl/src/prettier-plugin.ts
+++ b/packages/prettier-plugin-glsl/src/prettier-plugin.ts
@@ -264,8 +264,7 @@ function printBinaryishExpressions(
     )
 
     parts.push(
-      " ",
-      path.call(print, "op"),
+      n.kind === "commaExpression" ? "," : [" ", path.call(print, "op")],
       line,
       paren(
         path.call(print, "rhs"),


### PR DESCRIPTION
Fixes #31

## Problem

Formatting comma-separated expressions (comma operator) in constructs like curly-brace-less `for` loops produced invalid code because commas were silently dropped.

```glsl
// Input
for (int j = 0; ++j < 7; )
  a = 1, b = 2, c = 3;

// Output (broken) — commas missing
for (int j = 0; ++j < 7; )
  a = 1  b = 2  c = 3;
```

## Root cause

In `printBinaryishExpressions`, the `shouldFlatten` branch unconditionally used `path.call(print, "op")` to print the operator. This works for `BinaryExpression` nodes which have an `op` field, but `CommaExpression` nodes have no `op` field — the comma token is consumed as a separator by `AT_LEAST_ONE_SEP` and never stored. The non-flattening `else` branch already had a correct conditional check for this.

## Fix

Add the same conditional check to the `shouldFlatten` branch: emit a hardcoded `","` for `CommaExpression` nodes, and `[" ", path.call(print, "op")]` for `BinaryExpression` nodes.

## Test

Added `comma-expression.glsl` / `comma-expression.pretty.glsl` fixtures covering:
- Comma expressions in for-loop bodies (the reported case)
- Simple two-expression comma chains
- Longer chained comma expressions