### PR TITLE
Simplify release workflow & bump to v0.2.5

### DIFF
--- a/.github/workflows/release-prettier-plugin-glsl.yml
+++ b/.github/workflows/release-prettier-plugin-glsl.yml
@@ -1,17 +1,7 @@
 name: Release prettier-plugin-glsl
-description: "Release prettier-plugin-glsl to npm and update tags"
 
 on:
   workflow_dispatch:
-    inputs:
-      versionType:
-        description: "Version bump type"
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
 
 defaults:
   run:
@@ -39,19 +29,14 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Bump version
-        run: npm version ${{ inputs.versionType }} --no-git-tag-version
-
-      - name: Commit, tag, and push
+      - name: Tag
         run: |
           VERSION=$(jq --raw-output .version package.json)
           TAG="prettier-plugin-glsl-v${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "${TAG}"
           git tag "${TAG}"
-          git push --atomic origin HEAD "${TAG}"
+          git push origin "${TAG}"
 
       - name: Publish to npm
         run: npm publish

--- a/packages/prettier-plugin-glsl/package.json
+++ b/packages/prettier-plugin-glsl/package.json
@@ -9,7 +9,7 @@
     "src",
     "lib"
   ],
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Prettier (https://prettier.io) plugin for GLSL (OpenGL Shading Language).",
   "exports": {
     "default": "./lib/prettier-plugin.cjs.js",


### PR DESCRIPTION
## Changes

- **Simplify release workflow**: Remove version bump inputs and commit/push steps (the actions bot can't push to protected main). The workflow now assumes version is already bumped in `package.json` — it just builds, tests, tags, and publishes to npm.
- **Bump version to 0.2.5**: Includes the comma expression fix (#31) and toolchain updates.

### New release flow
1. Bump version in a PR, merge to main
2. Trigger the release workflow from Actions — it tags and publishes