### PR TITLE
fix: run npm ci from repo root so rimraf is available in release workflow

### DIFF
--- a/.github/workflows/release-prettier-plugin-glsl.yml
+++ b/.github/workflows/release-prettier-plugin-glsl.yml
@@ -22,7 +22,8 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
-      - run: npm ci --workspaces
+      - run: npm ci
+        working-directory: .
 
       - name: Build
         run: npm run build
@@ -41,4 +42,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish
-


### PR DESCRIPTION
The release workflow's default `working-directory` is `packages/prettier-plugin-glsl`. Running `npm ci --workspaces` from that subdirectory doesn't install root-level devDependencies like `rimraf`, causing the `prepublishOnly` script (`rimraf lib`) to fail during `npm publish`.

**Fix:** Run `npm ci` from the repo root (by overriding `working-directory: .`), which installs all dependencies including root-level `rimraf`.

Fixes the failure in [run #4](https://github.com/NaridaL/glsl-language-toolkit/actions/runs/24307145952/job/70970361062).