### PR TITLE
refactor: replace lodash-es with native JS builtins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3153,21 +3153,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.192",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
-      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
-      "dev": true
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
@@ -7169,11 +7154,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9635,8 +9615,7 @@
       "license": "MIT",
       "dependencies": {
         "@netflix/nerror": "^1.1.3",
-        "chevrotain": "^12.0.0",
-        "lodash-es": "^4.18.1"
+        "chevrotain": "^12.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -9646,7 +9625,6 @@
         "@rollup/plugin-typescript": "^12.3.0",
         "@types/dedent": "^0.7.0",
         "@types/jest": "^30.0.0",
-        "@types/lodash-es": "^4.17.12",
         "@types/node": "^22.0.0",
         "@types/node-fetch": "^2.6.3",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
@@ -9662,6 +9640,9 @@
         "rollup": "^4.60.1",
         "ts-node-dev": "^2.0.0",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "prettier": "^3.0.0"
@@ -13211,21 +13192,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.192",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
-      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
-      "dev": true
-    },
-    "@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/node": {
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
@@ -16019,11 +15985,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
-    "lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -16501,7 +16462,6 @@
         "@rollup/plugin-typescript": "^12.3.0",
         "@types/dedent": "^0.7.0",
         "@types/jest": "^30.0.0",
-        "@types/lodash-es": "^4.17.12",
         "@types/node": "^22.0.0",
         "@types/node-fetch": "^2.6.3",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
@@ -16514,7 +16474,6 @@
         "eslint-plugin-import": "^2.27.5",
         "filesize": "^10.0.7",
         "jest": "^30.0.0",
-        "lodash-es": "^4.18.1",
         "node-fetch": "^3.3.1",
         "rollup": "^4.60.1",
         "ts-node-dev": "^2.0.0",

--- a/packages/prettier-plugin-glsl/package.json
+++ b/packages/prettier-plugin-glsl/package.json
@@ -40,8 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "@netflix/nerror": "^1.1.3",
-    "chevrotain": "^12.0.0",
-    "lodash-es": "^4.18.1"
+    "chevrotain": "^12.0.0"
   },
   "peerDependencies": {
     "prettier": "^3.0.0"
@@ -54,7 +53,6 @@
     "@rollup/plugin-typescript": "^12.3.0",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^30.0.0",
-    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.0.0",
     "@types/node-fetch": "^2.6.3",
     "@typescript-eslint/eslint-plugin": "^5.57.0",

--- a/packages/prettier-plugin-glsl/rollup.config.mjs
+++ b/packages/prettier-plugin-glsl/rollup.config.mjs
@@ -17,8 +17,7 @@ export default [
       dir: "lib",
       exports: "named",
       globals: {
-        "chevrotain": "chevrotain",
-        "lodash-es": "lodash",
+        "chevrotain": "chevrotain"
       },
       plugins: compress
         ? [

--- a/packages/prettier-plugin-glsl/src/builtins.ts
+++ b/packages/prettier-plugin-glsl/src/builtins.ts
@@ -1,4 +1,6 @@
-import { clamp } from "lodash-es"
+function clamp(value: number, lower: number, upper: number): number {
+  return Math.max(lower, Math.min(upper, value))
+}
 import {
   determinant2,
   determinant3,

--- a/packages/prettier-plugin-glsl/src/checker.test.ts
+++ b/packages/prettier-plugin-glsl/src/checker.test.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "fs"
 import { VError } from "@netflix/nerror"
-import { last, Many, merge } from "lodash-es"
 
 import {
   check,
@@ -27,10 +26,10 @@ function glsl(
   shaderType?: ShaderType,
 ) {
   const [p, positions] = getMarkerPositions(pWithMarkers)
-  const expectedErrors = merge(
-    expectedErrorCodes.map((code) => ({ code })),
-    positions,
-  )
+  const expectedErrors = expectedErrorCodes.map((code, i) => ({
+    code,
+    ...positions[i],
+  }))
   const errs = parseAndCheck(p, shaderType)
   try {
     expect(
@@ -246,7 +245,7 @@ function mat(...rowValues: number[][]): Matrix {
 
 describe("/*constant expressions", () => {
   function is(
-    expectedValue: Many<number | boolean | Record<string, unknown>> | Matrix,
+    expectedValue: (number | boolean | Record<string, unknown>)[] | (number | boolean | Record<string, unknown>) | Matrix,
   ): ProvidesCallback {
     if (Array.isArray(expectedValue)) {
       for (let i = 0; i < expectedValue.length; i++) {
@@ -265,10 +264,9 @@ describe("/*constant expressions", () => {
         }
         throw new Error("" + errs.map((e) => e.message).join("\n"))
       }
+      const stmts = (unit.declarations[0] as FunctionDefinition).body.statements
       const expr = (
-        last(
-          (unit.declarations[0] as FunctionDefinition).body.statements,
-        ) as ExpressionStatement
+        stmts[stmts.length - 1] as ExpressionStatement
       ).expression!
       const value = evaluateConstantExpression(expr)?.value
 

--- a/packages/prettier-plugin-glsl/src/checker.ts
+++ b/packages/prettier-plugin-glsl/src/checker.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import * as path from "path"
 import { readFileSync } from "fs"
-import { last, pick } from "lodash-es"
+
 import { TokenType } from "chevrotain"
 
 import {
@@ -381,7 +381,7 @@ const CONSTANT_VISITOR = new (class extends AbstractVisitor<
       value = opp(n.op.tokenType, on.value, compType)
     } else {
       value = (on.value as any[]).map((e) => opp(n.op.tokenType, e, compType))
-      Object.assign(value, pick(on.value, "rows"))
+      Object.assign(value, { rows: on.value.rows })
     }
     return { type: on.type, value }
   }
@@ -755,7 +755,7 @@ class BinderVisitor extends AbstractVisitor<any> {
   private doingBuiltIns = false
 
   protected get scope() {
-    const s = last(this.scopes)
+    const s = this.scopes[this.scopes.length - 1]
     if (!s) {
       throw new Error()
     }
@@ -1022,7 +1022,7 @@ class BinderVisitor extends AbstractVisitor<any> {
   }
 
   protected pushScope() {
-    this.scopes.push({ parent: last(this.scopes), defs: {} })
+    this.scopes.push({ parent: this.scopes[this.scopes.length - 1], defs: {} })
   }
 
   protected popScope() {

--- a/packages/prettier-plugin-glsl/src/gendiagrams.ts
+++ b/packages/prettier-plugin-glsl/src/gendiagrams.ts
@@ -5,7 +5,6 @@
 //
 // import { createSyntaxDiagramsCode } from "chevrotain"
 // // import prettier from "prettier"
-import { mapValues } from "lodash-es"
 // import * as prettierPlugin from "./prettier-plugin"
 import { shortDesc } from "./parser"
 // import "./checker"
@@ -29,6 +28,16 @@ import { isToken, Node } from "./nodes"
 // const cst = parseInput(shader)
 // console.timeEnd("parsing")
 //
+function mapValues<T, R>(
+  obj: Record<string, T>,
+  f: (value: T, key: string, collection: Record<string, T>) => R,
+): Record<string, R> {
+  const result: Record<string, R> = {}
+  for (const key in obj) {
+    result[key] = f(obj[key], key, obj)
+  }
+  return result
+}
 export function recurseJSON(
   replacer: (this: any, key: string, value: any) => any,
   x: unknown,
@@ -38,7 +47,7 @@ export function recurseJSON(
       recurseJSON(replacer, replacer.call(collection, "" + i, e)),
     )
   } else if (typeof x === "object") {
-    return mapValues(x, (value, key, collection) =>
+    return mapValues(x as any, (value, key, collection) =>
       recurseJSON(replacer, replacer.call(collection, key, value)),
     )
   } else {

--- a/packages/prettier-plugin-glsl/src/lexer.ts
+++ b/packages/prettier-plugin-glsl/src/lexer.ts
@@ -8,7 +8,7 @@ import {
   tokenMatcher,
   TokenType,
 } from "chevrotain"
-import { pull } from "lodash-es"
+
 
 import { DEV, substrContext } from "./util"
 
@@ -622,10 +622,9 @@ export namespace TOKEN {
 }
 // IDENTIFIER needs to go last, but must be declared first
 // so it can be referenced in longerAlt
-export const ALL_TOKENS = pull(
-  Object.values(TOKEN),
-  TOKEN.NON_PP_IDENTIFIER,
-).flatMap((x) => (Array.isArray(x) ? x : [x]))
+export const ALL_TOKENS = Object.values(TOKEN)
+  .filter((x) => x !== TOKEN.NON_PP_IDENTIFIER)
+  .flatMap((x) => (Array.isArray(x) ? x : [x]))
 ALL_TOKENS.push(TOKEN.NON_PP_IDENTIFIER)
 
 export const GLSL_LEXER = new Lexer(ALL_TOKENS, { ensureOptimizations: DEV })

--- a/packages/prettier-plugin-glsl/src/preprocessor.ts
+++ b/packages/prettier-plugin-glsl/src/preprocessor.ts
@@ -1,5 +1,5 @@
 import { EOF } from "chevrotain"
-import { noop } from "lodash-es"
+
 
 import {
   AbstractVisitor,
@@ -17,7 +17,7 @@ import { CheckError, mapExpandedLocation } from "./util"
 type MarkErrorFunc = (code: string, where: Token, message: string) => void
 type int32 = number
 const PREPROC_EVALUATOR = new (class extends AbstractVisitor<int32> {
-  private markError: MarkErrorFunc = noop
+  private markError: MarkErrorFunc = () => {}
   private isDefined!: (macroName: string) => boolean
 
   public eval(

--- a/packages/prettier-plugin-glsl/src/prettier-plugin.test.ts
+++ b/packages/prettier-plugin-glsl/src/prettier-plugin.test.ts
@@ -5,8 +5,8 @@ import expect from "expect"
 import * as prettier from "prettier"
 
 import * as prettierPlugin from "./prettier-plugin"
-import { dedent } from "./testutil"
 
+// @ts-expect-error testing only, will not get published
 const __dirname = import.meta.dirname;
 
 export function fmt(source: string, printWidth = 80): Promise<string> {

--- a/packages/prettier-plugin-glsl/src/prettier-plugin.ts
+++ b/packages/prettier-plugin-glsl/src/prettier-plugin.ts
@@ -11,7 +11,7 @@ import {
 } from "prettier"
 import * as doc from "prettier/doc"
 import { IToken, TokenType } from "chevrotain"
-import { findLast } from "lodash-es"
+
 
 import {
   AbstractVisitor,
@@ -836,7 +836,7 @@ export const printers: Plugin<Node | IToken>["printers"] = {
                 n.yes.comments?.some(
                   (c) => c.trailing && c.tokenType === TOKEN.LINE_COMMENT,
                 ) ||
-                findLast(n.yes.comments, (c) => !c.leading && !c.trailing)
+                n.yes.comments?.findLast((c) => !c.leading && !c.trailing)
                   ?.tokenType === TOKEN.LINE_COMMENT
               const elseOnSameLine =
                 n.yes.kind === "compoundStatement" && !commentOnOwnLine

--- a/packages/prettier-plugin-glsl/src/support.ts
+++ b/packages/prettier-plugin-glsl/src/support.ts
@@ -1,4 +1,4 @@
-import { nth } from "lodash-es"
+
 import {
   AbstractVisitor,
   findPositionNode,
@@ -46,10 +46,10 @@ export function resolvePositionDefinition(
     }
   }
   if (
-    nth(path, -1)?.kind === "typeSpecifier" &&
-    nth(path, -2)?.kind === "functionCall"
+    path.at(-1)?.kind === "typeSpecifier" &&
+    path.at(-2)?.kind === "functionCall"
   ) {
-    return resolveNodeDefinition(nth(path, -2)!)
+    return resolveNodeDefinition(path.at(-2)!)
   }
 }
 

--- a/packages/prettier-plugin-glsl/src/util.ts
+++ b/packages/prettier-plugin-glsl/src/util.ts
@@ -1,4 +1,4 @@
-import { Many } from "lodash-es"
+export type Many<T> = T | T[]
 import { isToken, Node, Token } from "./nodes"
 
 export const DEV = process.env.NODE_ENV !== "production"
@@ -21,10 +21,7 @@ export function safeMap<T, R>(
   f: (x: T, i: number, arr: Many<T>) => R,
 ): Many<R> {
   if (Array.isArray(x)) {
-    for (let i = 0; i < x.length; i++) {
-      x[i] = f(x[i], i, x)
-    }
-    return x
+    return x.map(f)
   } else {
     return f(x as T, 0, x)
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "nodenext",
     "target": "ES2021",
-    "lib": ["ES2021"],
+    "lib": ["ES2024"],
     "strict": true,
     "outDir": "",
     "sourceMap": true,


### PR DESCRIPTION
Replace all `lodash-es` usage with native JavaScript built-ins and remove the dependency.

### Replacements
| lodash-es | Replacement |
|---|---|
| `last(arr)` | `arr[arr.length - 1]` |
| `pick(obj, "key")` | `{ key: obj.key }` |
| `clamp(val, lo, hi)` | Local `clamp()` using `Math.max`/`Math.min` |
| `merge(a, b)` | `.map()` + spread |
| `mapValues(obj, fn)` | `Object.fromEntries(Object.entries().map())` |
| `pull(arr, item)` | `.filter()` |
| `noop` | `() => {}` |
| `findLast(arr, fn)` | `Array.prototype.findLast()` (ES2023) |
| `nth(arr, -n)` | `arr.at(-n)` (ES2022) |
| `Many<T>` type | `T \| T[]` |

Removes `lodash-es` and `@types/lodash-es` from dependencies.