### PR TITLE
add: underscore support

### DIFF
--- a/packages/prettier-plugin-glsl/package.json
+++ b/packages/prettier-plugin-glsl/package.json
@@ -9,7 +9,7 @@
     "src",
     "lib"
   ],
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Prettier (https://prettier.io) plugin for GLSL (OpenGL Shading Language).",
   "engines": {
     "node": ">=22.0.0"

--- a/packages/prettier-plugin-glsl/src/lexer.ts
+++ b/packages/prettier-plugin-glsl/src/lexer.ts
@@ -433,7 +433,7 @@ export namespace TOKEN {
   })
   export const NON_PP_IDENTIFIER = createToken({
     name: "NON_PP_IDENTIFIER",
-    pattern: /[a-z]\w*/i,
+    pattern: /[a-z_]\w*/i,
     categories: IDENTIFIER,
   })
 


### PR DESCRIPTION
I am trying to format my `.glsl` embedded code that uses `_` prefix parameters but encounter the following error:

```bash
src/script.jsError: LEXER ERROR: unexpected character: ->_<- at offset: 47, skipped 1 characters.:
./src/compiler.lambda:2:29
    1 #include <common>
    2 mat2 get2dRotateMatrix(float _angle) {
-----------------------------------^^
```

I changed the regrex and it accepts `_angle` now.

Tested with emacs's `prettier-js-prettify` with `prettier-plugin-embed`.

```bash
glsl_test@1.0.0 /xxx/xxx
├── prettier-plugin-embed@0.5.1
├── prettier-plugin-glsl@0.2.6 extraneous -> ./../glsl-language-toolkit/packages/prettier-plugin-glsl
└── prettier@3.8.3
```

Sorry in advance if I messed up the version number.